### PR TITLE
README function typo

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -39,7 +39,7 @@ devtools::install_github("cboettig/minioclient")
 ## MinIO Client
 
 At first use, all operations will attempt to install the client if not already installed.
-Users can also install latest version of the minio client can be installed using `install_minio()`.
+Users can also install latest version of the minio client can be installed using `install_mc`.
 
 ```{r}
 library(minioclient)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ devtools::install_github("cboettig/minioclient")
 
 At first use, all operations will attempt to install the client if not
 already installed. Users can also install latest version of the minio
-client can be installed using `install_minio()`.
+client can be installed using `install_mc()`.
 
 ``` r
 library(minioclient)


### PR DESCRIPTION
I ran into an error when I tried `install_minio`, which I believe is a typo.

(Thanks for the package. Looks cool!)