### PR TITLE
Bugfix: Allow for spaces in config paths

### DIFF
--- a/R/mc.R
+++ b/R/mc.R
@@ -27,8 +27,8 @@ mc <- function(command, ..., path = minio_path(), verbose = interactive()) {
     if(proceed) install_mc()
   }
   
-  command <- paste("--config-dir", path, command)
-  args <- strsplit(command, split = " ")[[1]]
+  command <- paste("--config-dir", shQuote(path), command)
+  args <- scan(text = command, what = 'character', quiet = TRUE)
   p <- processx::run(binary, args, ...)
   
   if(p$timeout & verbose) warning(paste("request", command, "timed out"))

--- a/R/mc_rb.R
+++ b/R/mc_rb.R
@@ -10,9 +10,14 @@
 #' mc_rb("play/my-bucket")
 #'
 #' @export
-mc_rb <- function(bucket) {
+mc_rb <- function(bucket, force = FALSE) {
   if(interactive()){
     proceed <- utils::askYesNo("Are you sure?")
+  } else {
+    proceed = force
+    if(!proceed) {
+      message("Run `mc_rb()` interactively or with force=TRUE")
+    }
   }
   
   if(!proceed){ 

--- a/R/mc_rb.R
+++ b/R/mc_rb.R
@@ -1,6 +1,7 @@
 #' Remove an S3 bucket using mc command
 #'
 #' @param bucket Character string specifying the name of the bucket to remove
+#' @param force Delete bucket without confirmation in non-interactive mode
 #' @inherit mc return
 #'
 #' @examplesIf interactive()

--- a/man/mc_rb.Rd
+++ b/man/mc_rb.Rd
@@ -4,10 +4,12 @@
 \alias{mc_rb}
 \title{Remove an S3 bucket using mc command}
 \usage{
-mc_rb(bucket)
+mc_rb(bucket, force = FALSE)
 }
 \arguments{
 \item{bucket}{Character string specifying the name of the bucket to remove}
+
+\item{force}{Delete bucket without confirmation in non-interactive mode}
 }
 \value{
 Returns the list from \code{\link[processx:run]{processx::run()}}, with components \code{status},


### PR DESCRIPTION
The default install and config location on macOS is `Users/<USER>/Library/Application Support/org.R-project.R/R/minioclient`.  This has a space in it, so when `mc()` is run the path is then broken up by the `strplit` call.   This patch quotes the path and uses `scan` instead of `striplit` to avoid splitting within quotes.

I note one reason this may have been missed is that the default for `r-lib/actions/check-r-package` is to run `--as-cran`, and most tests use `skip_on_cran()`.

I also added a `force` argument to `mc_rb()`, as it was failing tests without it. 